### PR TITLE
implement caching for all items and fix various bugs related to caching

### DIFF
--- a/src/main/java/org/zeroBzeroT/antiillegals/CachedState.java
+++ b/src/main/java/org/zeroBzeroT/antiillegals/CachedState.java
@@ -1,0 +1,29 @@
+package org.zeroBzeroT.antiillegals;
+
+import org.bukkit.inventory.ItemStack;
+
+public class CachedState {
+
+    private final ItemStack revertedStack;
+    private final AntiIllegals.ItemState revertedState;
+
+    public CachedState(final ItemStack revertedStack,
+                       final AntiIllegals.ItemState revertedState) {
+        this.revertedStack = revertedStack;
+        this.revertedState = revertedState;
+    }
+
+    public void applyRevertedState(final ItemStack cached) {
+        if (revertedState == AntiIllegals.ItemState.clean) return; // nothing to change
+
+        cached.setItemMeta(revertedStack.getItemMeta());
+        cached.setDurability(revertedStack.getDurability());
+        cached.setData(revertedStack.getData());
+        cached.setAmount(revertedStack.getAmount());
+    }
+
+    public AntiIllegals.ItemState revertedState() {
+        return revertedState;
+    }
+
+}

--- a/src/main/java/org/zeroBzeroT/antiillegals/RevertionResult.java
+++ b/src/main/java/org/zeroBzeroT/antiillegals/RevertionResult.java
@@ -1,0 +1,21 @@
+package org.zeroBzeroT.antiillegals;
+
+public class RevertionResult {
+
+    private final int books;
+    private final boolean wasReverted;
+
+    public RevertionResult(final int books, final boolean wasReverted) {
+        this.books = books;
+        this.wasReverted = wasReverted;
+    }
+
+    public int books() {
+        return books;
+    }
+
+    public boolean wasReverted() {
+        return wasReverted;
+    }
+
+}


### PR DESCRIPTION
implement caching for all sorts of items; single items can cause extreme lag as well in some cases. this patch also includes bugfixes such as item meta hash codes not properly being calculated and items changing their nbt when they shouldn't (when recoloring shulkers, they lost all of their content in the previous patch)