### PR TITLE
added 1.21 and 1.20 items to materials helper + illegal materials in config.yml

### DIFF
--- a/src/main/java/org/zeroBzeroT/antiillegals/helpers/MaterialHelper.java
+++ b/src/main/java/org/zeroBzeroT/antiillegals/helpers/MaterialHelper.java
@@ -38,6 +38,11 @@ public class MaterialHelper {
             Material.LEATHER_LEGGINGS,
             Material.LEATHER_BOOTS,
             Material.ELYTRA
+            Material.NETHERITE_HELMET
+            Material.NETHERITE_CHESTPLATE
+            Material.NETHERITE_LEGGINGS
+            Material.NETHERITE_BOOTS
+            Material.TURTLE_HELMET
     );
 
     @NotNull
@@ -53,6 +58,11 @@ public class MaterialHelper {
             Material.GOLDEN_SWORD,
             Material.DIAMOND_SWORD,
             Material.BOW
+            Material.NETHERITE_AXE
+            Material.NETHERITE_SWORD
+            Material.CROSSBOW
+            Material.MACE
+            Material.TRIDENT
     );
 
     @NotNull
@@ -76,6 +86,11 @@ public class MaterialHelper {
             Material.FISHING_ROD,
             Material.SHEARS,
             Material.SHIELD
+            Material.NETHERITE_PICKAXE
+            Material.NETHERITE_SHOVEL
+            Material.NETHERITE_HOE
+            Material.BRUSH
+            Material.WARPED_FUNGUS_ON_A_STICK
     );
 
     @Nullable
@@ -86,10 +101,17 @@ public class MaterialHelper {
             Material.BEACON,
             Material.BREWING_STAND,
             Material.CHEST,
+            Material.TRAPPED_CHEST
             Material.DISPENSER,
             Material.DROPPER,
             Material.FURNACE,
-            Material.HOPPER
+            Material.HOPPER,
+            Material.BARREL
+            Material.BUNDLE
+            Material.SMOKER
+            Material.BLAST_FURNACE
+            Material.MINECART_WITH_HOPPER
+            Material.MINECART_WITH_CHEST
     );
 
     public static void loadIllegalMaterials() {

--- a/src/main/java/org/zeroBzeroT/antiillegals/helpers/MaterialHelper.java
+++ b/src/main/java/org/zeroBzeroT/antiillegals/helpers/MaterialHelper.java
@@ -37,11 +37,11 @@ public class MaterialHelper {
             Material.LEATHER_CHESTPLATE,
             Material.LEATHER_LEGGINGS,
             Material.LEATHER_BOOTS,
-            Material.ELYTRA
-            Material.NETHERITE_HELMET
-            Material.NETHERITE_CHESTPLATE
-            Material.NETHERITE_LEGGINGS
-            Material.NETHERITE_BOOTS
+            Material.ELYTRA,
+            Material.NETHERITE_HELMET,
+            Material.NETHERITE_CHESTPLATE,
+            Material.NETHERITE_LEGGINGS,
+            Material.NETHERITE_BOOTS,
             Material.TURTLE_HELMET
     );
 
@@ -57,11 +57,11 @@ public class MaterialHelper {
             Material.IRON_SWORD,
             Material.GOLDEN_SWORD,
             Material.DIAMOND_SWORD,
-            Material.BOW
-            Material.NETHERITE_AXE
-            Material.NETHERITE_SWORD
-            Material.CROSSBOW
-            Material.MACE
+            Material.BOW,
+            Material.NETHERITE_AXE,
+            Material.NETHERITE_SWORD,
+            Material.CROSSBOW,
+            Material.MACE,
             Material.TRIDENT
     );
 
@@ -85,11 +85,11 @@ public class MaterialHelper {
             Material.FLINT_AND_STEEL,
             Material.FISHING_ROD,
             Material.SHEARS,
-            Material.SHIELD
-            Material.NETHERITE_PICKAXE
-            Material.NETHERITE_SHOVEL
-            Material.NETHERITE_HOE
-            Material.BRUSH
+            Material.SHIELD,
+            Material.NETHERITE_PICKAXE,
+            Material.NETHERITE_SHOVEL,
+            Material.NETHERITE_HOE,
+            Material.BRUSH,
             Material.WARPED_FUNGUS_ON_A_STICK
     );
 
@@ -101,16 +101,16 @@ public class MaterialHelper {
             Material.BEACON,
             Material.BREWING_STAND,
             Material.CHEST,
-            Material.TRAPPED_CHEST
+            Material.TRAPPED_CHEST,
             Material.DISPENSER,
             Material.DROPPER,
             Material.FURNACE,
             Material.HOPPER,
-            Material.BARREL
-            Material.BUNDLE
-            Material.SMOKER
-            Material.BLAST_FURNACE
-            Material.MINECART_WITH_HOPPER
+            Material.BARREL,
+            Material.BUNDLE,
+            Material.SMOKER,
+            Material.BLAST_FURNACE,
+            Material.MINECART_WITH_HOPPER,
             Material.MINECART_WITH_CHEST
     );
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,8 +29,9 @@ illegalMaterials:
   - "*_spawn_egg"
   - "jigsaw"
   - "light"
-  - "reinforced_deepslate"
   - "debug_stick"
+  - "vault"
+  - "trial_spawner"
 
 # technically illegal, but not reverting these by default
 # - "bundle"
@@ -39,3 +40,6 @@ illegalMaterials:
 # - "farmland"
 # - "budding_amethyst"
 # - "infested_*"
+#  - "reinforced_deepslate"
+#  - "dirt_path"
+#  - "knowledge_book"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,7 @@ illegalMaterials:
   - "debug_stick"
   - "vault"
   - "trial_spawner"
+  - "reinforced_deepslate"
 
 # technically illegal, but not reverting these by default
 # - "bundle"
@@ -40,6 +41,5 @@ illegalMaterials:
 # - "farmland"
 # - "budding_amethyst"
 # - "infested_*"
-#  - "reinforced_deepslate"
 #  - "dirt_path"
 #  - "knowledge_book"


### PR DESCRIPTION
added illegal armor/weapons/tools/non_shulker_containers being;
NETHERITE_HELMET
NETHERITE_CHESTPLATE
NETHERITE_LEGGINGS
NETHERITE_BOOTS
TURTLE_HELMET

NETHERITE_AXE
NETHERITE_SWORD
CROSSBOW
MACE
TRIDENT

NETHERITE_PICKAXE
NETHERITE_SHOVEL
NETHERITE_HOE
BRUSH
WARPED_FUNGUS_ON_A_STICK

TRAPPED_CHEST
BARREL
BUNDLE
SMOKER
BLAST_FURNACE
MINECART_WITH_HOPPER
MINECART_WITH_CHEST


added illegal materials being;
TRIAL_SPAWNER
VAULT


added technically illegals being;
dirt_path
knowledge_book


by the way **effect.minecraft.unluck** and **effect.minecraft.luck** are unobtainable effects unless spawned in by an admin or given using commands if you want to make it so that it clears on login. (i have no clue how to do this!)